### PR TITLE
tagging mongodb server to 5.0.6 to support the unsupported OP_QUERY commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 harvested_data/*
+crawler/*
+service/*
+website/*

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ $ docker-compose build
 $ docker-compose up
 ```
 
+*NOTE: If you have an issue seeding, prune all volumes, containers, and images then try again.*
+
 And head to http://localhost:3000 to see your running website UI along with some seeded data!
 
 You can also query the service API with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - "--inspect=0.0.0.0:9229"
       - "./index.js"
   clearlydefined_mongo_db:
-    image: "mongo:latest"
+    image: "mongo:5.0.6"
     ports:
       - "27017:27017"
   clearlydefined_mongo_seed:


### PR DESCRIPTION
ClearlyDefined service mongodb driver uses 3.1.x. This version internally uses `OP_QUERY` when invoking <collection>.find() which is no longer supported in mongodb server 6.0 and above. `mongodb:latest` currently pulls 6.0 which breaks the `service` service.