### PR TITLE
Use mongo definition store for dev environment set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ CURATION_PROVIDER="github"
 CURATION_STORE_PROVIDER="mongo"
 
 # Definition Store Info
-DEFINITION_STORE_PROVIDER="mongoTrimmed"
+DEFINITION_STORE_PROVIDER="mongo"
 DEFINITION_MONGO_CONNECTION_STRING="mongodb://clearlydefined_mongo_db"
 DEFINITION_MONGO_DB_NAME="clearlydefined"
-DEFINITION_MONGO_TRIMMED_COLLECTION_NAME="definitions-trimmed"
+DEFINITION_MONGO_COLLECTION_NAME="definitions-paged"
 
 # Harvest Store Info
 HARVEST_STORE_PROVIDER="file"
@@ -247,12 +247,16 @@ run these commands and you should see newly harvested data.
 
 This container holds a Mongo database called **clearlydefined**
 
-The database contains two collections:
+The database contains the following collections:
 * curations (contains curations)
-* definitions-trimmed (contains definitions)
+* definitions-paged (contains definitions)
+* definitions-trimmed (contains definitions without files)
 
-The reason the definitions database is called definitions-trimmed is because, previously, the definitions collection was paged. The pagination was added in [this January 2019 pull request](https://github.com/clearlydefined/service/pull/364). To improve performance and reduce cost of the definition database, [this Feb 2023 pull request](https://github.com/clearlydefined/service/pull/976) subsequently stores definitions without files. Our production Azure setup includes definitions-trimmed, that is actively used. This development environment includes the definitions-trimmed collection in order to mirror production.
-This collection is seeded using the Clearly Defined Mongo Seed container.
+Our production Azure setup includes definitions-trimmed, that is actively used. The reason the definitions collection is called definitions-trimmed is because, previously, the definitions collection was paged. The pagination was added in [this January 2019 pull request](https://github.com/clearlydefined/service/pull/364). To improve performance and reduce cost of the definition database, [this Feb 2023 pull request](https://github.com/clearlydefined/service/pull/976) subsequently stores definitions without files. 
+
+The sample setup uses definitions-paged instead of definitions-trimmed because definitions-trimmed works well as part of a definition store collection, but not on its own. In comparison, definitions-paged collection stores the definitions in entirety, and can be used as a standalone definitions store. To emulate the production environment more closely, one can use dispatch+file+mongoTrimmed as DEFINITION_STORE_PROVIDER.
+
+These collections are seeded using the Clearly Defined Mongo Seed container.
 
 If you have [mongodb](https://docs.mongodb.com/manual/installation/) installed on your local system, you can attach to the Mongo database with:
 
@@ -265,7 +269,7 @@ You can also do this through the [Docker desktop client](https://www.docker.com/
 
 ### Clearly Defined Mongo Seed
 
-This container exists only to seed initial data into the Clearly Defined Mongo DB. It populates both the collections and definitions-trimmed collections with sample data.
+This container exists only to seed initial data into the Clearly Defined Mongo DB. It populates the collections with sample data.
 
 ## Using
 

--- a/mongo_seed/definitions/angular-paged.json
+++ b/mongo_seed/definitions/angular-paged.json
@@ -1,0 +1,148 @@
+[{
+  "_id": "npm/npmjs/-/angular/1.6.9",
+  "described": {
+    "releaseDate": "2018-02-02",
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "url": "https://github.com/angular/angular.js/tree/c3c5c5eea2eeff82b1ae6c855a4508f8ff51cedc",
+      "revision": "c3c5c5eea2eeff82b1ae6c855a4508f8ff51cedc",
+      "namespace": "angular",
+      "name": "angular.js"
+    },
+    "urls": {
+      "registry": "https://npmjs.com/package/angular",
+      "version": "https://npmjs.com/package/angular/v/1.6.9",
+      "download": "https://registry.npmjs.com/angular/-/angular-1.6.9.tgz"
+    },
+    "projectWebsite": "http://angularjs.org",
+    "issueTracker": "https://github.com/angular/angular.js/issues",
+    "tools": [
+      "clearlydefined/1",
+      "scancode/2.2.1"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "files": [
+    {
+      "path": "package/LICENSE.md",
+      "license": "MIT",
+      "natures": [
+        "license"
+      ],
+      "attributions": [
+        "Copyright (c) 2016 Angular"
+      ],
+      "hashes": {
+        "sha1": "682346b34c58e0a9d2deb60ccd8b8c55cb474cea"
+      }
+    },
+    {
+      "path": "package/bower.json",
+      "hashes": {
+        "sha1": "d57e302f201d7ccff4430b1a81611812b210fb15"
+      }
+    },
+    {
+      "path": "package/angular.min.js",
+      "attributions": [
+        "(c) 2010-2018 Google, Inc. http://angularjs.org"
+      ],
+      "hashes": {
+        "sha1": "382ea6ce5bb85a666aa9fb35a4c24eed58441258"
+      }
+    },
+    {
+      "path": "package/package.json",
+      "license": "MIT",
+      "hashes": {
+        "sha1": "c479ce5c51b4b5dac7b7a79700f22a50343475f9"
+      }
+    },
+    {
+      "path": "package/angular.js",
+      "attributions": [
+        "(c) 2010-2018 Google, Inc. http://angularjs.org"
+      ],
+      "hashes": {
+        "sha1": "4eb1606146f3aca57d69d1b55c7b0384f538b77d"
+      }
+    },
+    {
+      "path": "package/README.md",
+      "license": "MIT",
+      "attributions": [
+        "Copyright (c) 2010-2015 Google, Inc. http://angularjs.org"
+      ],
+      "hashes": {
+        "sha1": "fc6245aa21a1c521fc39955cc04d3959c68aee95"
+      }
+    }
+  ],
+  "licensed": {
+    "declared": "MIT",
+    "toolScore": {
+      "total": 68,
+      "declared": 30,
+      "discovered": 8,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 2,
+          "parties": [
+            "Copyright (c) 2016 Angular",
+            "(c) 2010-2018 Google, Inc. http://angularjs.org",
+            "Copyright (c) 2010-2015 Google, Inc. http://angularjs.org"
+          ]
+        },
+        "discovered": {
+          "unknown": 3,
+          "expressions": [
+            "MIT"
+          ]
+        },
+        "files": 6
+      }
+    },
+    "score": {
+      "total": 68,
+      "declared": 30,
+      "discovered": 8,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    }
+  },
+  "coordinates": {
+    "type": "npm",
+    "provider": "npmjs",
+    "name": "angular",
+    "revision": "1.6.9"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.0",
+    "updated": "2019-03-11T14:25:35.991Z"
+  },
+  "scores": {
+    "effective": 84,
+    "tool": 84
+  },
+  "_mongo": {
+    "partitionKey": "npm/npmjs/-/angular/1.6.9",
+    "page": 1,
+    "totalPages": 1
+  }
+}]

--- a/mongo_seed/definitions/flyway-maven-plugin-paged.json
+++ b/mongo_seed/definitions/flyway-maven-plugin-paged.json
@@ -1,0 +1,73 @@
+[
+  {
+    "_id": "maven/mavencentral/org.flywaydb/flyway-maven-plugin/5.0.7",
+    "described": {
+      "sourceLocation": {
+        "type": "sourcearchive",
+        "provider": "mavencentral",
+        "url": "http://central.maven.org/maven2/org/flywaydb/flyway-maven-plugin/5.0.7/flyway-maven-plugin-5.0.7-sources.jar",
+        "revision": "5.0.7",
+        "namespace": "org.flywaydb",
+        "name": "flyway-maven-plugin"
+      },
+      "releaseDate": "2018-01-30",
+      "urls": {
+        "registry": "http://central.maven.org/maven2/org/flywaydb/flyway-maven-plugin",
+        "version": "http://central.maven.org/maven2/org/flywaydb/flyway-maven-plugin/5.0.7",
+        "download": "http://central.maven.org/maven2/org/flywaydb/flyway-maven-plugin/5.0.7/flyway-maven-plugin-5.0.7.jar"
+      },
+      "tools": [
+        "clearlydefined/1"
+      ],
+      "toolScore": {
+        "total": 100,
+        "date": 30,
+        "source": 70
+      },
+      "score": {
+        "total": 100,
+        "date": 30,
+        "source": 70
+      }
+    },
+    "licensed": {
+      "declared": "NOASSERTION",
+      "toolScore": {
+        "total": 15,
+        "declared": 0,
+        "discovered": 0,
+        "consistency": 15,
+        "spdx": 0,
+        "texts": 0
+      },
+      "score": {
+        "total": 15,
+        "declared": 0,
+        "discovered": 0,
+        "consistency": 15,
+        "spdx": 0,
+        "texts": 0
+      }
+    },
+    "coordinates": {
+      "type": "maven",
+      "provider": "mavencentral",
+      "namespace": "org.flywaydb",
+      "name": "flyway-maven-plugin",
+      "revision": "5.0.7"
+    },
+    "_meta": {
+      "schemaVersion": "1.6.1",
+      "updated": "2019-11-04T21:59:21.238Z"
+    },
+    "scores": {
+      "effective": 57,
+      "tool": 57
+    },
+    "_mongo": {
+      "partitionKey": "maven/mavencentral/org.flywaydb/flyway-maven-plugin/5.0.7",
+      "page": 1,
+      "totalPages": 1
+    }
+  }
+]

--- a/mongo_seed/seed_data.sh
+++ b/mongo_seed/seed_data.sh
@@ -3,4 +3,6 @@
 
 mongoimport --host clearlydefined_mongo_db --db clearlydefined --collection definitions-trimmed --type json --file definitions/angular.json --jsonArray
 mongoimport --host clearlydefined_mongo_db --db clearlydefined --collection definitions-trimmed --type json --file definitions/flyway-maven-plugin.json --jsonArray
+mongoimport --host clearlydefined_mongo_db --db clearlydefined --collection definitions-paged --type json --file definitions/angular-paged.json --jsonArray
+mongoimport --host clearlydefined_mongo_db --db clearlydefined --collection definitions-paged --type json --file definitions/flyway-maven-plugin-paged.json --jsonArray
 mongoimport --host clearlydefined_mongo_db --db clearlydefined --collection curations --type json --file curations/387.json --jsonArray

--- a/sample_env
+++ b/sample_env
@@ -15,10 +15,10 @@ CURATION_STORE_PROVIDER="mongo"
 GITLAB_TOKEN="<your GitLab token (unless you are working on code that interacts with the GitLab API, this can be a random string of characters)>"
 
 # Definition Store Info
-DEFINITION_STORE_PROVIDER="mongoTrimmed"
+DEFINITION_STORE_PROVIDER="mongo"
 DEFINITION_MONGO_CONNECTION_STRING="mongodb://clearlydefined_mongo_db"
 DEFINITION_MONGO_DB_NAME="clearlydefined"
-DEFINITION_MONGO_TRIMMED_COLLECTION_NAME="definitions-trimmed"
+DEFINITION_MONGO_COLLECTION_NAME="definitions-paged"
 
 # Harvest Store Info
 HARVEST_STORE_PROVIDER="file"


### PR DESCRIPTION
Use mongo and definitions-paged collection for definitions store in dev environment set up.  This is because the trimmed mongo definition store (mongoTrimmed, which uses definitions-trimmed collection) works well as part of a definition store collection, but not on its own. In comparison, definitions-paged collection stores the definitions in entirety, and can be used as a standalone definitions store.

Populating the definitions-trimmed collection is kept in place to make this distinction between dev environment and production deployment more evident.  To emulate the production environment more closely, one can use dispatch+file+mongoTrimmed as DEFINITION_STORE_PROVIDER

Task: https://github.com/clearlydefined/service/issues/983