### PR TITLE
Update README.md and docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ services:
       - "5000:5000"
 ```
 
-If you are using MAC systems and your CPU does not have an AVX support, please change the version of Mongo from 5.0.6 to 4.4.28 in docker-compose.yml file. 
+If you are using a Mac computer and your CPU does not have a AVX support, please change the version of Mongo from 5.0.6 to 4.4.28 in docker-compose.yml file. 
 ```bash
 clearlydefined_mongo_db:
     image: "mongo:4.4.28"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ services:
       - "5000:5000"
 ```
 
+If you are using MAC systems, please change the version of Mongo from 5.0.6 to 4.4.28 in docker-compose.yml file. 
+```bash
+clearlydefined_mongo_db:
+    image: "mongo:4.4.28"
+    ports:
+      - "27017:27017"
+```
+
 ### Setting up environmental variables
 
 This environment handles environmental variables a little differently from the [historical Clearly Defined dev environment instructions](https://docs.clearlydefined.io/contributing-code).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ services:
       - "5000:5000"
 ```
 
-If you are using MAC systems, please change the version of Mongo from 5.0.6 to 4.4.28 in docker-compose.yml file. 
+If you are using MAC systems and your CPU does not have an AVX support, please change the version of Mongo from 5.0.6 to 4.4.28 in docker-compose.yml file. 
 ```bash
 clearlydefined_mongo_db:
     image: "mongo:4.4.28"

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ You can also do this through the [Docker desktop client](https://www.docker.com/
 
 This container exists only to seed initial data into the Clearly Defined Mongo DB. It populates the collections with sample data.
 
+If you wish to build this container yourself, please follow the instructions [https://github.com/clearlydefined/docker_dev_env_experiment/blob/main/mongo_seed/README.md](here)
+
 ## Using
 
 As noted above, you can start all of the containers with:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ You can also do this through the [Docker desktop client](https://www.docker.com/
 
 This container exists only to seed initial data into the Clearly Defined Mongo DB. It populates the collections with sample data.
 
-If you wish to build this container yourself, please follow the instructions [https://github.com/clearlydefined/docker_dev_env_experiment/blob/main/mongo_seed/README.md](here)
+If you wish to build this container yourself, please follow the instructions [here](https://github.com/clearlydefined/docker_dev_env_experiment/blob/main/mongo_seed/README.md)
 
 ## Using
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,12 +45,10 @@ services:
       - "--inspect=0.0.0.0:9229"
       - "./index.js"
   clearlydefined_mongo_db:
-    platform: linux/amd64
     image: "mongo:5.0.6"
     ports:
       - "27017:27017"
   clearlydefined_mongo_seed:
-    platform: linux/amd64
     image: "clearlydefined/docker_dev_env_experiment_clearlydefined_mongo_seed"
     links:
       - clearlydefined_mongo_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@
 version: "3.8"
 services:
   web:
+    platform: linux/amd64
     build:
       context: ./website
       dockerfile: DevDockerfile
@@ -11,6 +12,7 @@ services:
       - "3000:3000"
     stdin_open: true
   service:
+    platform: linux/amd64
     build:
       context: ./service
       dockerfile: DevDockerfile
@@ -28,6 +30,7 @@ services:
       - clearlydefined_mongo_db
       - crawler
   crawler:
+    platform: linux/amd64
     build:
       context: ./crawler
       dockerfile: DevDockerfile
@@ -42,13 +45,12 @@ services:
       - "--inspect=0.0.0.0:9229"
       - "./index.js"
   clearlydefined_mongo_db:
+    platform: linux/amd64
     image: "mongo:5.0.6"
     ports:
       - "27017:27017"
   clearlydefined_mongo_seed:
+    platform: linux/amd64
     image: "clearlydefined/docker_dev_env_experiment_clearlydefined_mongo_seed"
-    build:
-      context: ./mongo_seed
-      dockerfile: Dockerfile
     links:
       - clearlydefined_mongo_db


### PR DESCRIPTION
The README.md and docker-compose.yml file has been updated to fix the setup issues in development environment on MAC systems.

Platform flag has been added as "**linux/amd64**" to web, service and crawler services in docker-compose.yml file to maintain the compatibility. 

The MongoDB version should be downgraded to 4.4.28 from 5.0.6 in case mac systems do not have an AVX support. The step to downgrade the MongoDB version has been updated in the README.MD file.