### PR TITLE
ignore repos that are cloned separately in this repo for development on localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-harvested_data/*
-crawler/*
-service/*
-website/*
+harvested_data/
+crawler/
+service/
+website/


### PR DESCRIPTION
Part of the instructions after cloning this repo is to clone additional repos at the root of the new clone.  This includes the major apps for running the CD infrastructure:

* website
* service
* crawler

This PR adjusts the previous ignores, changing the form `crawler/*` to `crawler/`.  The former ignores all files in the crawler folder, but leaves the folder itself.  The later ignores the crawler folder and all its contents.