### PR TITLE
include mongo:4.4.28 in docker-compose as a comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - "--inspect=0.0.0.0:9229"
       - "./index.js"
   clearlydefined_mongo_db:
+    # image: "mongo:4.4.28"
     image: "mongo:5.0.6"
     ports:
       - "27017:27017"


### PR DESCRIPTION
Including a comment that brings in the mongo:4.4.28 image makes it easier for mac users to run this on localhost.

To use on a Mac computer and your CPU does not have a AVX support:

* uncomment `image: “mongo:4.4.28”`
* comment out `image: “mongo:5.0.6”

_This PR is a NO_OP as no code or process is changed._